### PR TITLE
update for zig 0.14.0-dev.655+d30d37e35

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,14 +19,14 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const module = b.addModule("prettytable", .{
-        .root_source_file = .{ .path = "src/lib.zig" },
+        .root_source_file = b.path("src/lib.zig"),
     });
 
     const lib = b.addStaticLibrary(.{
         .name = "prettytable-zig",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
-        .root_source_file = .{ .path = "src/lib.zig" },
+        .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -48,7 +48,7 @@ pub fn build(b: *std.Build) void {
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
     const main_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/lib.zig" },
+        .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -56,35 +56,35 @@ pub fn build(b: *std.Build) void {
     const run_main_tests = b.addRunArtifact(main_tests);
 
     const format_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/format.zig" },
+        .root_source_file = b.path("src/format.zig"),
         .target = target,
         .optimize = optimize,
     });
     const run_format_tests = b.addRunArtifact(format_tests);
 
     const cell_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/cell.zig" },
+        .root_source_file = b.path("src/cell.zig"),
         .target = target,
         .optimize = optimize,
     });
     const run_cell_tests = b.addRunArtifact(cell_tests);
 
     const row_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/row.zig" },
+        .root_source_file = b.path("src/row.zig"),
         .target = target,
         .optimize = optimize,
     });
     const run_row_tests = b.addRunArtifact(row_tests);
 
     const table_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/table.zig" },
+        .root_source_file = b.path("src/table.zig"),
         .target = target,
         .optimize = optimize,
     });
     const run_table_tests = b.addRunArtifact(table_tests);
 
     const style_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/style.zig" },
+        .root_source_file = b.path("src/style.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -113,7 +113,7 @@ pub fn buildExample(b: *std.Build, optimize: Mode, target: ResolvedTarget, modul
             .name = s,
             // In this case the main source file is merely a path, however, in more
             // complicated build scripts, this could be a generated file.
-            .root_source_file = .{ .path = "examples/" ++ s ++ ".zig" },
+            .root_source_file = b.path("examples/" ++ s ++ ".zig"),
             .target = target,
             .optimize = optimize,
         });

--- a/src/cell.zig
+++ b/src/cell.zig
@@ -30,7 +30,7 @@ pub const Cell = struct {
     /// Create a new `Cell` initialized with content from `string`.
     /// Text alignment in cell is configurable with the `align` argument
     pub fn initWithAlign(allocator: std.mem.Allocator, string: String, align_: Alignment) !Self {
-        var it = std.mem.split(u8, string, line_sep);
+        var it = std.mem.splitSequence(u8, string, line_sep);
         var content = std.ArrayList(String).init(allocator);
         var width: usize = 0;
         while (it.next()) |item| {

--- a/src/table.zig
+++ b/src/table.zig
@@ -261,7 +261,7 @@ pub const Table = struct {
         var flag = has_title;
         while (try reader.readUntilDelimiterOrEof(buf, '\n')) |line| {
             const i = self._data.items.len;
-            var it = std.mem.split(u8, line, sep);
+            var it = std.mem.splitSequence(u8, line, sep);
             while (it.next()) |data| {
                 const new_data = try self.allocator.alloc(u8, data.len);
                 @memcpy(new_data, data);


### PR DESCRIPTION
Hi there,

Just bumped into this very nice library and wanted to use it in a project. But as I am using a newer version of Zig, I had a few problems with the build, which I believe are fixed by this PR. Basically, I did two things:

- changed relative path references in build.zig that require a `LazyPath` to use the `b.path` method. The previous structure was deprecated/does not work anymore;
- Replaced methods to split sequences (in `cell.zig` and `table.zig`): from `std.mem.split` (which was deprecated) to `std.mem.splitSequence`