### PR TITLE
feat!: use `Io.Reader/Writer` interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,11 @@ One scenario is to read data from a CSV file.
         \\
     ;
 
-    var s = std.io.fixedBufferStream(data);
-    var reader = s.reader();
+    var reader: std.Io.Reader = .fixed(data);
     var table = Table.init(std.heap.page_allocator);
     defer table.deinit();
 
-    var read_buf: [1024]u8 = undefined;
-    try table.readFrom(reader, &read_buf, ",", true);
+    try table.readFrom(&reader, ",", true);
 
     try table.printstd();
 ```
@@ -205,13 +203,11 @@ One scenario is to read data from a CSV file.
 ### Get the table as string(bytes)
 
 ```zig
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.heap.page_allocator);
+    var aw: std.Io.Writer.Allocating = .init(std.heap.page_allocator);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
-    var out = buf.writer(std.heap.page_allocator);
-    _ = try table.print(out);
-
-    // buf.items is the bytes of table
+    // aw.written() is the bytes of table
 ```
 
 ### Change print format

--- a/examples/multiline.zig
+++ b/examples/multiline.zig
@@ -13,17 +13,15 @@ pub fn main() !void {
         &[_][]const u8{ "1", "2" },
     });
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = try table1.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    _ = try table1.print(&aw.writer);
 
     var table2 = Table.init(gpa);
     defer table2.deinit();
 
     try table2.addRows(&[_][]const []const u8{
         &[_][]const u8{ "A", "B", "C" },
-        &[_][]const u8{ "This is\na multiline\ncell", "2", buf.items },
+        &[_][]const u8{ "This is\na multiline\ncell", "2", aw.written() },
     });
 
     try table2.printstd();

--- a/examples/read.zig
+++ b/examples/read.zig
@@ -10,13 +10,12 @@ pub fn main() !void {
         \\
     ;
 
-    var s = std.io.fixedBufferStream(data);
-    const reader = s.reader();
+    var reader: std.Io.Reader = .fixed(data);
+
     var table = Table.init(std.heap.page_allocator);
     defer table.deinit();
 
-    var read_buf: [1024]u8 = undefined;
-    try table.readFrom(reader, &read_buf, ",", true);
+    try table.readFrom(&reader, ",", true);
 
     try table.printstd();
     // +-------+-----+----------------+

--- a/src/cell.zig
+++ b/src/cell.zig
@@ -110,16 +110,16 @@ pub const Cell = struct {
         return try std.mem.join(allocator, line_sep, self.content.items);
     }
 
-    pub fn print(self: Self, allocator: std.mem.Allocator, out: anytype, idx: usize, colWidth: usize, skipRightFill: bool) void {
+    pub fn print(self: Self, allocator: std.mem.Allocator, writer: *std.Io.Writer, idx: usize, colWidth: usize, skipRightFill: bool) void {
         _ = allocator;
         var c: []const u8 = "";
         if (self.content.items.len > idx) {
             c = self.content.items[idx];
         }
-        return self.printAlign(out, self.align_, c, " ", colWidth, skipRightFill) catch return;
+        return self.printAlign(writer, self.align_, c, " ", colWidth, skipRightFill) catch return;
     }
 
-    pub fn printTerm(self: Self, allocator: std.mem.Allocator, out: anytype, idx: usize, colWidth: usize, skipRightFill: bool) void {
+    pub fn printTerm(self: Self, allocator: std.mem.Allocator, writer: *std.Io.Writer, idx: usize, colWidth: usize, skipRightFill: bool) void {
         var buf = allocator.alloc(u8, 16) catch return;
         defer allocator.free(buf);
         const len = self.style.toAnsi(buf) catch return;
@@ -127,10 +127,10 @@ pub const Cell = struct {
         // std.mem.copy(u8, d[0..prefix.len], prefix[0..prefix.len]);
         // @memcpy(d, prefix);
         // std.debug.print("Buck {any} {d}\r\n", .{d, d.len});
-        _ = out.write(buf[0..len]) catch return;
+        _ = writer.write(buf[0..len]) catch return;
         // _ = out.write("hello") catch return;
-        self.print(allocator, out, idx, colWidth, skipRightFill);
-        _ = out.write("\x1b[0m") catch return;
+        self.print(allocator, writer, idx, colWidth, skipRightFill);
+        _ = writer.write("\x1b[0m") catch return;
     }
 
     /// Align/fill a string and print it to `out`
@@ -138,7 +138,7 @@ pub const Cell = struct {
     /// to complete alignment
     pub fn printAlign(
         self: Self,
-        out: anytype,
+        writer: *std.Io.Writer,
         align_: Alignment,
         text: []const u8,
         fill: []const u8,
@@ -165,14 +165,14 @@ pub const Cell = struct {
         }
         if (n > 0) {
             for (0..n) |_| {
-                _ = try out.write(fill);
+                _ = try writer.write(fill);
             }
             nfill -= n;
         }
-        _ = try out.writeAll(text);
+        _ = try writer.writeAll(text);
         if (nfill > 0 and !skipRightFill) {
             for (0..nfill) |_| {
-                _ = try out.write(fill);
+                _ = try writer.write(fill);
             }
         }
         return;
@@ -196,12 +196,11 @@ test "test print ascii" {
 
     try testing.expect(cell.getWidth() == 5);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
 
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
-    try testing.expect(eql(u8, buf.items, "hello     "));
+    _ = cell.print(gpa, &aw.writer, 0, 10, false);
+    try testing.expect(eql(u8, aw.written(), "hello     "));
 }
 
 test "test align left" {
@@ -211,12 +210,11 @@ test "test align left" {
 
     try testing.expect(cell.getWidth() == 4);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = cell.print(gpa, &aw.writer, 0, 10, false);
 
-    try testing.expect(eql(u8, buf.items, "test      "));
+    try testing.expect(eql(u8, aw.written(), "test      "));
 }
 
 test "test align center" {
@@ -226,12 +224,11 @@ test "test align center" {
 
     try testing.expect(cell.getWidth() == 4);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = cell.print(gpa, &aw.writer, 0, 10, false);
 
-    try testing.expect(eql(u8, buf.items, "   test   "));
+    try testing.expect(eql(u8, aw.written(), "   test   "));
 }
 
 test "test align right" {
@@ -241,12 +238,11 @@ test "test align right" {
 
     try testing.expect(cell.getWidth() == 4);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = cell.print(gpa, &aw.writer, 0, 10, false);
 
-    try testing.expect(eql(u8, buf.items, "      test"));
+    try testing.expect(eql(u8, aw.written(), "      test"));
 }
 
 test "test cell with unicode characters" {
@@ -279,26 +275,25 @@ test "test cell with unicode characters" {
 }
 
 test "test cell unicode alignment" {
-    const allocator = testing.allocator;
+    const gpa = testing.allocator;
 
     // Initialize Unicode display width calculator
     const initDisplayWidth = @import("./utils.zig").initDisplayWidth;
     const deinitDisplayWidth = @import("./utils.zig").deinitDisplayWidth;
 
-    try initDisplayWidth(allocator);
-    defer deinitDisplayWidth(allocator);
+    try initDisplayWidth(gpa);
+    defer deinitDisplayWidth(gpa);
 
-    var cell = try Cell.initWithAlign(allocator, "你好", Alignment.center);
+    var cell = try Cell.initWithAlign(gpa, "你好", Alignment.center);
     defer cell.deinit();
 
     try testing.expectEqual(@as(usize, 4), cell.getWidth());
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-    const out = buf.writer(allocator);
-    _ = cell.print(allocator, out, 0, 10, false);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = cell.print(gpa, &aw.writer, 0, 10, false);
 
     // Chinese characters "你好" has display width 4, center aligned in width 10 space
     // Left padding 3 spaces, right padding 3 spaces
-    try testing.expectEqualStrings("   你好   ", buf.items);
+    try testing.expectEqualStrings("   你好   ", aw.written());
 }

--- a/src/format.zig
+++ b/src/format.zig
@@ -68,9 +68,9 @@ pub const LineSeparator = struct {
         return Self.new("-", "+", "+", "+");
     }
 
-    fn print(self: Self, out: anytype, colWidth: []const usize, lpadding: usize, rpadding: usize, colsep: bool, lborder: bool, rborder: bool) !usize {
+    fn print(self: Self, writer: *std.Io.Writer, colWidth: []const usize, lpadding: usize, rpadding: usize, colsep: bool, lborder: bool, rborder: bool) !usize {
         if (lborder) {
-            _ = try out.write(self.ljunc);
+            _ = try writer.write(self.ljunc);
         }
 
         var i: usize = 0;
@@ -78,18 +78,18 @@ pub const LineSeparator = struct {
         while (i < colWidth.len) {
             const width = colWidth[i];
             for (0..(width + lpadding + rpadding)) |_| {
-                _ = try out.write(self.line);
+                _ = try writer.write(self.line);
             }
             if (colsep and i + 1 < colWidth.len) {
-                _ = try out.write(self.junc);
+                _ = try writer.write(self.junc);
             }
 
             i += 1;
         }
         if (rborder) {
-            _ = try out.write(self.rjunc);
+            _ = try writer.write(self.rjunc);
         }
-        _ = try out.write(line_sep);
+        _ = try writer.write(line_sep);
         return 1;
     }
 };
@@ -240,24 +240,24 @@ pub const TableFormat = struct {
         }
     }
 
-    pub fn printLineSeparator(self: Self, out: anytype, colWidth: []const usize, pos: LinePosition) !usize {
+    pub fn printLineSeparator(self: Self, writer: *std.Io.Writer, colWidth: []const usize, pos: LinePosition) !usize {
         const sep = self.getSepForLine(pos);
         if (sep == null) {
             return 0;
         }
         for (0..self.getIndent()) |_| {
-            try out.writeAll(" ");
+            try writer.writeAll(" ");
         }
-        return sep.?.print(out, colWidth, self.getLPadding(), self.getRPadding(), self.csep != null, self.lborder != null, self.rborder != null);
+        return sep.?.print(writer, colWidth, self.getLPadding(), self.getRPadding(), self.csep != null, self.lborder != null, self.rborder != null);
     }
 
-    pub fn printColumnSeparator(self: Self, out: anytype, pos: ColumnPosition) !void {
+    pub fn printColumnSeparator(self: Self, writer: *std.Io.Writer, pos: ColumnPosition) !void {
         const s = self.getColumnSeparator(pos);
         if (s == null) {
             return;
         }
 
-        _ = try out.writeAll(s.?);
+        _ = try writer.writeAll(s.?);
     }
 };
 

--- a/src/row.zig
+++ b/src/row.zig
@@ -162,22 +162,22 @@ pub const Row = struct {
         return 0;
     }
 
-    pub fn print(self: Self, out: anytype, format: TableFormat, colWidth: []const usize) usize {
-        return self.internalPrint(out, format, colWidth, Cell.print) catch return 0;
+    pub fn print(self: Self, writer: *std.Io.Writer, format: TableFormat, colWidth: []const usize) usize {
+        return self.internalPrint(writer, format, colWidth, Cell.print) catch return 0;
     }
 
-    pub fn printTerm(self: Self, out: anytype, format: TableFormat, colWidth: []const usize) usize {
-        return self.internalPrint(out, format, colWidth, Cell.printTerm) catch return 0;
+    pub fn printTerm(self: Self, writer: *std.Io.Writer, format: TableFormat, colWidth: []const usize) usize {
+        return self.internalPrint(writer, format, colWidth, Cell.printTerm) catch return 0;
     }
 
-    fn internalPrint(self: Self, out: anytype, format: TableFormat, colWidth: []const usize, f: fn (Cell, allocator: std.mem.Allocator, out: anytype, usize, usize, bool) void) !usize {
+    fn internalPrint(self: Self, writer: *std.Io.Writer, format: TableFormat, colWidth: []const usize, f: fn (Cell, allocator: std.mem.Allocator, writer: *std.Io.Writer, usize, usize, bool) void) !usize {
         const height = self.getHeight();
         for (0..height) |i| {
             for (0..format.getIndent()) |_| {
-                _ = try out.write(" ");
+                _ = try writer.write(" ");
             }
 
-            try format.printColumnSeparator(out, ColumnPosition.left);
+            try format.printColumnSeparator(writer, ColumnPosition.left);
 
             const lp = format.getLPadding();
             const rp = format.getRPadding();
@@ -188,7 +188,7 @@ pub const Row = struct {
             while (j + hspan < colWidth.len) {
                 var k: usize = 0;
                 while (k < lp) {
-                    _ = try out.write(" "); // Left padding
+                    _ = try writer.write(" "); // Left padding
                     k += 1;
                 }
                 // skip_r_fill skip filling the end of the last cell if there's no character
@@ -198,7 +198,7 @@ pub const Row = struct {
                 if (cell == null) {
                     var empty = try Cell.default(self.allocator);
                     defer empty.deinit();
-                    _ = f(empty, self.allocator, out, i, colWidth[j + hspan], skip_r_fill);
+                    _ = f(empty, self.allocator, writer, i, colWidth[j + hspan], skip_r_fill);
                 } else {
 
                     // In case of horizontal spanning, width is the sum of all spanned columns' width
@@ -219,21 +219,21 @@ pub const Row = struct {
                     }
 
                     // Print cell content
-                    _ = f(cell.?, self.allocator, out, i, w, skip_r_fill);
+                    _ = f(cell.?, self.allocator, writer, i, w, skip_r_fill);
                     hspan += real_span; // Add span to offset
                 }
                 var n: usize = 0;
                 while (n < rp) {
                     n += 1;
                 }
-                _ = try out.write(" "); // Right padding
+                _ = try writer.write(" "); // Right padding
                 if (j + hspan < colWidth.len - 1) {
-                    try format.printColumnSeparator(out, ColumnPosition.intern);
+                    try format.printColumnSeparator(writer, ColumnPosition.intern);
                 }
                 j += 1;
             }
-            try format.printColumnSeparator(out, ColumnPosition.right);
-            _ = try out.writeAll(line_sep);
+            try format.printColumnSeparator(writer, ColumnPosition.right);
+            _ = try writer.writeAll(line_sep);
         }
         return height;
     }
@@ -323,18 +323,20 @@ test "test remove cell" {
 }
 
 test "test print" {
+    const gpa = testing.allocator;
     const t = @import("./format.zig");
     const data = [_][]const u8{ "foo", "bar", "foobar" };
-    var r = try row(testing.allocator, &data);
+    var r = try row(gpa, &data);
     defer r.deinit();
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(testing.allocator);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = r.print(&aw.writer, t.FORMAT_DEFAULT, &[_]usize{ 10, 10, 10 });
 
-    const out = buf.writer(testing.allocator);
-    _ = r.print(out, t.FORMAT_DEFAULT, &[_]usize{ 10, 10, 10 });
-
-    try testing.expect(eql(u8, buf.items, "| foo        | bar        | foobar     |" ++ line_sep));
+    try testing.expectEqualStrings(
+        "| foo        | bar        | foobar     |" ++ line_sep,
+        aw.written(),
+    );
 }
 
 // test "test extend cell" {

--- a/src/table.zig
+++ b/src/table.zig
@@ -265,9 +265,9 @@ pub const Table = struct {
         return colWidth;
     }
 
-    pub fn readFrom(self: *Self, reader: anytype, buf: []u8, sep: []const u8, has_title: bool) !void {
+    pub fn readFrom(self: *Self, reader: *std.Io.Reader, sep: []const u8, has_title: bool) !void {
         var flag = has_title;
-        while (try reader.readUntilDelimiterOrEof(buf, '\n')) |line| {
+        while (try reader.takeDelimiter('\n')) |line| {
             const i = self._data.items.len;
             var it = std.mem.splitSequence(u8, line, sep);
             while (it.next()) |data| {
@@ -318,35 +318,35 @@ pub const Table = struct {
         try stdout.flush();
     }
 
-    pub fn print(self: Self, out: anytype) !void {
-        _ = try self.internalPrint(out, Row.print);
+    pub fn print(self: Self, writer: *std.Io.Writer) !void {
+        _ = try self.internalPrint(writer, Row.print);
     }
 
-    pub fn printTerm(self: Self, out: anytype) !void {
-        _ = try self.internalPrint(out, Row.printTerm);
+    pub fn printTerm(self: Self, writer: *std.Io.Writer) !void {
+        _ = try self.internalPrint(writer, Row.printTerm);
     }
 
     // TODO: anytype
-    fn internalPrint(self: Self, out: anytype, f: fn (Row, anytype, TableFormat, []const usize) usize) !usize {
+    fn internalPrint(self: Self, writer: *std.Io.Writer, f: fn (Row, *std.Io.Writer, TableFormat, []const usize) usize) !usize {
         var height: usize = 0;
         var colWidth = try self.getAllColumnWidth(self.allocator);
         defer colWidth.deinit(self.allocator);
 
-        height += try self.format.printLineSeparator(out, colWidth.items, LinePosition.top);
+        height += try self.format.printLineSeparator(writer, colWidth.items, LinePosition.top);
         if (self.titles != null) {
-            height += f(self.titles.?, out, self.format, colWidth.items);
-            height += try self.format.printLineSeparator(out, colWidth.items, LinePosition.title);
+            height += f(self.titles.?, writer, self.format, colWidth.items);
+            height += try self.format.printLineSeparator(writer, colWidth.items, LinePosition.title);
         }
 
         for (0..self.rows.items.len) |i| {
             const r = self.rows.items[i];
-            height += f(r, out, self.format, colWidth.items);
+            height += f(r, writer, self.format, colWidth.items);
             if (i + 1 < self.rows.items.len) {
-                height += try self.format.printLineSeparator(out, colWidth.items, LinePosition.intern);
+                height += try self.format.printLineSeparator(writer, colWidth.items, LinePosition.intern);
             }
         }
 
-        height += try self.format.printLineSeparator(out, colWidth.items, LinePosition.bottom);
+        height += try self.format.printLineSeparator(writer, colWidth.items, LinePosition.bottom);
 
         return height;
     }
@@ -360,11 +360,9 @@ test "test print table" {
     defer table.deinit();
     try table.addRow(&row1);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+-----+------+---------+
@@ -372,7 +370,10 @@ test "test print table" {
         \\+-----+------+---------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(
+        expect,
+        aw.written(),
+    );
 }
 
 test "test print mulitline table" {
@@ -386,11 +387,9 @@ test "test print mulitline table" {
         &[_][]const u8{ "1", "2", "3" },
     });
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+--------+------+---------+
@@ -402,7 +401,7 @@ test "test print mulitline table" {
         \\+--------+------+---------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test print table with title" {
@@ -416,11 +415,9 @@ test "test print table with title" {
     try table.addRow(&row1);
     try table.setTitle(&title);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+--------+------+------+
@@ -430,7 +427,7 @@ test "test print table with title" {
         \\+--------+------+------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test print table with format" {
@@ -442,11 +439,9 @@ test "test print table with format" {
     try table.addRow(&row1);
     table.setFormat(@import("./format.zig").FORMAT_BOX_CHARS);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\┌────────┬─────┬─────┐
@@ -454,7 +449,7 @@ test "test print table with format" {
         \\└────────┴─────┴─────┘
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test print table with mulitline cell" {
@@ -466,11 +461,9 @@ test "test print table with mulitline cell" {
 
     try table.addRow(&row1);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+-----+-----+-----+
@@ -479,7 +472,7 @@ test "test print table with mulitline cell" {
         \\+-----+-----+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test print table with inconsistent columns" {
@@ -493,11 +486,9 @@ test "test print table with inconsistent columns" {
     try table.addRow(&row1);
     try table.addRow(&row2);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+--------+-----+-----+
@@ -507,7 +498,7 @@ test "test print table with inconsistent columns" {
         \\+--------+-----+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test nest table" {
@@ -516,33 +507,29 @@ test "test nest table" {
     const row1 = [_][]const u8{ "foobar", "foo", "bar" };
     const row2 = [_][]const u8{ "1", "2" };
 
-    var table1 = Table.init(testing.allocator);
-    defer table1.deinit();
+    var table_inner = Table.init(testing.allocator);
+    defer table_inner.deinit();
 
-    try table1.addRow(&row1);
-    try table1.addRow(&row2);
+    try table_inner.addRow(&row1);
+    try table_inner.addRow(&row2);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    var out = buf.writer(gpa);
-
-    _ = try table1.print(out);
+    var aw_inner: std.Io.Writer.Allocating = .init(gpa);
+    defer aw_inner.deinit();
+    _ = try table_inner.print(&aw_inner.writer);
 
     // Table 2
     const row3 = [_][]const u8{ "A", "B", "C" };
-    const row4 = [_][]const u8{ "1", "2", buf.items };
+    const row4 = [_][]const u8{ "1", "2", aw_inner.written() };
 
-    var table2 = Table.init(testing.allocator);
-    defer table2.deinit();
+    var table_outer = Table.init(testing.allocator);
+    defer table_outer.deinit();
 
-    try table2.addRow(&row3);
-    try table2.addRow(&row4);
+    try table_outer.addRow(&row3);
+    try table_outer.addRow(&row4);
 
-    var buf2: std.ArrayList(u8) = .empty;
-    defer buf2.deinit(gpa);
-    out = buf2.writer(gpa);
-
-    _ = try table2.print(out);
+    var aw_outer: std.Io.Writer.Allocating = .init(gpa);
+    defer aw_outer.deinit();
+    _ = try table_outer.print(&aw_outer.writer);
 
     const expect =
         \\+---+---+------------------------+
@@ -557,7 +544,7 @@ test "test nest table" {
         \\+---+---+------------------------+
         \\
     ;
-    try testing.expect(eql(u8, buf2.items, expect));
+    try testing.expectEqualStrings(expect, aw_outer.written());
 }
 
 test "test insert and remove row" {
@@ -574,11 +561,9 @@ test "test insert and remove row" {
     try table.insertRow(0, &row3);
     table.removeRow(1);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+-----+------+---------+
@@ -588,7 +573,7 @@ test "test insert and remove row" {
         \\+-----+------+---------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test get and set cell" {
@@ -606,11 +591,9 @@ test "test get and set cell" {
 
     try table.setCell(0, 0, "FOOBAR");
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+--------+-----+-----+
@@ -620,7 +603,7 @@ test "test get and set cell" {
         \\+--------+-----+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test table alignment" {
@@ -636,11 +619,9 @@ test "test table alignment" {
 
     table.setAlign(Alignment.right);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+-----+---------+-----+
@@ -650,7 +631,7 @@ test "test table alignment" {
         \\+-----+---------+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test column alignment" {
@@ -666,11 +647,9 @@ test "test column alignment" {
 
     table.setColumnAlign(1, Alignment.right);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     const expect =
         \\+-----+---------+-----+
@@ -680,7 +659,7 @@ test "test column alignment" {
         \\+-----+---------+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test read from" {
@@ -693,20 +672,16 @@ test "test read from" {
         \\
     ;
 
-    var s = std.io.fixedBufferStream(data);
-    const reader = s.reader();
+    var reader: std.Io.Reader = .fixed(data);
 
     var table = Table.init(gpa);
     defer table.deinit();
 
-    var read_buf: [1024]u8 = undefined;
-    try table.readFrom(reader, &read_buf, ",", false);
+    try table.readFrom(&reader, ",", false);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
     const expect =
         \\+---------+----+------------+
         \\| quincy  |  1 |  hot dogs  |
@@ -720,7 +695,7 @@ test "test read from" {
         \\
     ;
 
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test read from with title" {
@@ -732,20 +707,16 @@ test "test read from with title" {
         \\
     ;
 
-    var s = std.io.fixedBufferStream(data);
-    const reader = s.reader();
+    var reader: std.Io.Reader = .fixed(data);
 
     var table = Table.init(gpa);
     defer table.deinit();
 
-    var read_buf: [1024]u8 = undefined;
-    try table.readFrom(reader, &read_buf, ",", true);
+    try table.readFrom(&reader, ",", true);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
     const expect =
         \\+-------+-----+----------------+
         \\| name  |  id |  favorite food |
@@ -757,7 +728,7 @@ test "test read from with title" {
         \\
     ;
 
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expectEqualStrings(expect, aw.written());
 }
 
 test "test color" {
@@ -768,14 +739,12 @@ test "test color" {
     try table.addRow(&[_][]const u8{"1"});
     try table.setCellStyle(0, 0, .{ .bold = true, .fg = .red });
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.printTerm(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.printTerm(&aw.writer);
     const expect = [_]u8{ 43, 45, 45, 45, 43, 10, 124, 32, 27, 91, 51, 49, 59, 52, 57, 59, 49, 109, 49, 27, 91, 48, 109, 32, 124, 10, 43, 45, 45, 45, 43, 10 };
 
-    try testing.expect(eql(u8, buf.items, &expect));
+    try testing.expect(eql(u8, aw.written(), &expect));
 }
 
 test "test table with unicode characters" {
@@ -792,16 +761,14 @@ test "test table with unicode characters" {
     try table.addRow(&row2);
     try table.addRow(&row3);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     // Verify output contains correct Unicode characters
-    try testing.expect(std.mem.indexOf(u8, buf.items, "姓名") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "张三") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "工程师") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "姓名") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "张三") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "工程师") != null);
 }
 
 test "test table with emoji" {
@@ -818,15 +785,13 @@ test "test table with emoji" {
     try table.addRow(&row2);
     try table.addRow(&row3);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     // Verify output contains correct emoji
-    try testing.expect(std.mem.indexOf(u8, buf.items, "😊") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "😢") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "😊") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "😢") != null);
 }
 
 test "test table mixed unicode and ascii" {
@@ -843,14 +808,12 @@ test "test table mixed unicode and ascii" {
     try table.addRow(&row2);
     try table.addRow(&row3);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-
-    _ = try table.print(out);
+    var aw: std.Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    _ = try table.print(&aw.writer);
 
     // Verify output contains mixed characters
-    try testing.expect(std.mem.indexOf(u8, buf.items, "苹果") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "👍") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "😊") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "苹果") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "👍") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "😊") != null);
 }


### PR DESCRIPTION
This PR updates the package to use the `Io.Reader/Writer` interfaces added in Zig 0.15.1

(Note that it is a breaking change)

This doesn't do all the fancy things that could be possible using the new readers/writers, like having a `format` function on `Table`, or auditing the previous usage of the "out" parameter to see if `*std.Io.Writer` has some functions that makes things easier, but I am trying to keep this PR simple since it touches so many files.