### PR TITLE
refactor!: Update to zig 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /zig-out/
 /zig-cache/
 .zig-cache
+/zig-pkg/zg-0.15.3-oGqU3BaetgIIRXXxyGsXtvmYgi1XLf4HHvHswqsgLo-Y

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,7 +8,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
@@ -17,8 +17,8 @@
     // Internet connectivity.
     .dependencies = .{
         .zg = .{
-            .url = "https://codeberg.org/atman/zg/archive/v0.15.4.tar.gz",
-            .hash = "zg-0.15.3-oGqU3P5ItAJHmwDLfzX6sg6Xc5MhSJU2TctHfWu_sKLv",
+            .url = "https://codeberg.org/atman/zg/archive/v0.16.0.tar.gz",
+            .hash = "zg-0.15.3-oGqU3BaetgIIRXXxyGsXtvmYgi1XLf4HHvHswqsgLo-Y",
         },
     },
     .paths = .{

--- a/examples/align.zig
+++ b/examples/align.zig
@@ -3,7 +3,9 @@ const Table = @import("prettytable").Table;
 const Alignment = @import("prettytable").Alignment;
 const FORMAT_BOX_CHARS = @import("prettytable").FORMAT_BOX_CHARS;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     var table = Table.init(std.heap.page_allocator);
     defer table.deinit();
 
@@ -14,7 +16,7 @@ pub fn main() !void {
 
     table.setAlign(Alignment.right);
 
-    try table.printstd();
+    try table.printstd(io);
     // +-----+---------+-----+
     // | foo | foooooo | bar |
     // +-----+---------+-----+

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const Table = @import("prettytable").Table;
 const FORMAT_BOX_CHARS = @import("prettytable").FORMAT_BOX_CHARS;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     // Create ad table
     var table = Table.init(std.heap.page_allocator);
     defer table.deinit();
@@ -15,7 +17,7 @@ pub fn main() !void {
     // add single row
     try table.addRow(&[_][]const u8{ "1", "2", "3" });
 
-    try table.printstd();
+    try table.printstd(io);
     // +-----+-----+-----+
     // | A   | B   | C   |
     // +-----+-----+-----+

--- a/examples/format.zig
+++ b/examples/format.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const pt = @import("prettytable");
 const Table = pt.Table;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     var table = Table.init(std.heap.page_allocator);
     defer table.deinit();
 
@@ -14,43 +16,43 @@ pub fn main() !void {
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_DEFAULT"});
     table.setFormat(pt.FORMAT_DEFAULT);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_NO_TITLE"});
     table.setFormat(pt.FORMAT_NO_TITLE);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_NO_LINESEP_WITH_TITLE"});
     table.setFormat(pt.FORMAT_NO_LINESEP_WITH_TITLE);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_NO_LINESEP"});
     table.setFormat(pt.FORMAT_NO_LINESEP);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_NO_COLSEP"});
     table.setFormat(pt.FORMAT_NO_COLSEP);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_CLEAN"});
     table.setFormat(pt.FORMAT_CLEAN);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_BORDERS_ONLY"});
     table.setFormat(pt.FORMAT_BORDERS_ONLY);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_NO_BORDER"});
     table.setFormat(pt.FORMAT_NO_BORDER);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_NO_BORDER_LINE_SEPARATOR"});
     table.setFormat(pt.FORMAT_NO_BORDER_LINE_SEPARATOR);
-    try table.printstd();
+    try table.printstd(io);
 
     std.debug.print("\n\n{s}\n", .{"FORMAT_BOX_CHARS"});
     table.setFormat(pt.FORMAT_BOX_CHARS);
-    try table.printstd();
+    try table.printstd(io);
 
     // FORMAT_DEFAULT
     // +------+------+--------+

--- a/examples/multiline.zig
+++ b/examples/multiline.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const Table = @import("prettytable").Table;
 const FORMAT_BOX_CHARS = @import("prettytable").FORMAT_BOX_CHARS;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     const gpa = std.heap.page_allocator;
 
     var table1 = Table.init(gpa);
@@ -13,20 +15,19 @@ pub fn main() !void {
         &[_][]const u8{ "1", "2" },
     });
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = try table1.print(out);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
+    _ = try table1.print(&out.writer);
 
     var table2 = Table.init(gpa);
     defer table2.deinit();
 
     try table2.addRows(&[_][]const []const u8{
         &[_][]const u8{ "A", "B", "C" },
-        &[_][]const u8{ "This is\na multiline\ncell", "2", buf.items },
+        &[_][]const u8{ "This is\na multiline\ncell", "2", out.written() },
     });
 
-    try table2.printstd();
+    try table2.printstd(io);
 
     // +-------------+---+------------------------+
     // | A           | B | C                      |

--- a/examples/read.zig
+++ b/examples/read.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const Table = @import("prettytable").Table;
 const FORMAT_BOX_CHARS = @import("prettytable").FORMAT_BOX_CHARS;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     const data =
         \\name, id, favorite food
         \\beau, 2, cereal
@@ -10,15 +12,13 @@ pub fn main() !void {
         \\
     ;
 
-    var s = std.io.fixedBufferStream(data);
-    const reader = s.reader();
+    var reader: std.Io.Reader = .fixed(data);
     var table = Table.init(std.heap.page_allocator);
     defer table.deinit();
 
-    var read_buf: [1024]u8 = undefined;
-    try table.readFrom(reader, &read_buf, ",", true);
+    try table.readFrom(&reader, ",", true);
 
-    try table.printstd();
+    try table.printstd(io);
     // +-------+-----+----------------+
     // | name  |  id |  favorite food |
     // +=======+=====+================+

--- a/examples/style.zig
+++ b/examples/style.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const Table = @import("prettytable").Table;
 const FORMAT_BOX_CHARS = @import("prettytable").FORMAT_BOX_CHARS;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init ) !void {
+    const io = init.io;
+
     var table = Table.init(std.heap.page_allocator);
     defer table.deinit();
 
@@ -18,5 +20,5 @@ pub fn main() !void {
     try table.setCellStyle(1, 0, .{ .fg = .black, .bg = .cyan });
     try table.setCellStyle(1, 1, .{ .fg = .black, .bg = .blue });
     try table.setCellStyle(1, 2, .{ .fg = .black, .bg = .white });
-    _ = try table.print_tty(true);
+    _ = try table.print_tty(io, true);
 }

--- a/examples/unicode.zig
+++ b/examples/unicode.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const prettytable = @import("prettytable");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     const allocator = std.heap.page_allocator;
 
     // Example 1: Chinese character table
@@ -18,7 +20,7 @@ pub fn main() !void {
         try table.addRow(&[_][]const u8{ "王五", "28", "UI设计师", "深圳" });
 
         std.debug.print("=== 中文字符表格 ===\n", .{});
-        try table.printstd();
+        try table.printstd(io);
         std.debug.print("\n", .{});
     }
 
@@ -35,7 +37,7 @@ pub fn main() !void {
         try table.addRow(&[_][]const u8{ "Diana", "🤔", "Thinking", "⭐⭐⭐⭐⭐" });
 
         std.debug.print("=== Emoji 表格 ===\n", .{});
-        try table.printstd();
+        try table.printstd(io);
         std.debug.print("\n", .{});
     }
 
@@ -52,7 +54,7 @@ pub fn main() !void {
         try table.addRow(&[_][]const u8{ "草莓 🍓", "$4.99", "超级好 💯", "日本" });
 
         std.debug.print("=== 混合字符表格 ===\n", .{});
-        try table.printstd();
+        try table.printstd(io);
         std.debug.print("\n", .{});
     }
 
@@ -68,7 +70,7 @@ pub fn main() !void {
         try table.addRow(&[_][]const u8{ "박민수", "28", "기획자", "대구" });
 
         std.debug.print("=== 韩文字符表格 ===\n", .{});
-        try table.printstd();
+        try table.printstd(io);
         std.debug.print("\n", .{});
     }
 
@@ -86,7 +88,7 @@ pub fn main() !void {
         table.setAlign(prettytable.Alignment.right);
 
         std.debug.print("=== 右对齐 Unicode 表格 ===\n", .{});
-        try table.printstd();
+        try table.printstd(io);
         std.debug.print("\n", .{});
     }
 
@@ -105,7 +107,7 @@ pub fn main() !void {
         table.setFormat(prettytable.FORMAT_BOX_CHARS);
 
         std.debug.print("=== Box 字符格式 Unicode 表格 ===\n", .{});
-        try table.printstd();
+        try table.printstd(io);
         std.debug.print("\n", .{});
     }
 }

--- a/src/cell.zig
+++ b/src/cell.zig
@@ -196,12 +196,10 @@ test "test print ascii" {
 
     try testing.expect(cell.getWidth() == 5);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
-    try testing.expect(eql(u8, buf.items, "hello     "));
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
+    _ = cell.print(gpa, &out.writer, 0, 10, false);
+    try testing.expect(eql(u8, out.written(), "hello     "));
 }
 
 test "test align left" {
@@ -211,12 +209,11 @@ test "test align left" {
 
     try testing.expect(cell.getWidth() == 4);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
+    _ = cell.print(gpa, &out.writer, 0, 10, false);
 
-    try testing.expect(eql(u8, buf.items, "test      "));
+    try testing.expect(eql(u8, out.written(), "test      "));
 }
 
 test "test align center" {
@@ -226,12 +223,11 @@ test "test align center" {
 
     try testing.expect(cell.getWidth() == 4);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
+    _ = cell.print(gpa, &out.writer, 0, 10, false);
 
-    try testing.expect(eql(u8, buf.items, "   test   "));
+    try testing.expect(eql(u8, out.written(), "   test   "));
 }
 
 test "test align right" {
@@ -241,23 +237,15 @@ test "test align right" {
 
     try testing.expect(cell.getWidth() == 4);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
-    _ = cell.print(gpa, out, 0, 10, false);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
+    _ = cell.print(gpa, &out.writer, 0, 10, false);
 
-    try testing.expect(eql(u8, buf.items, "      test"));
+    try testing.expect(eql(u8, out.written(), "      test"));
 }
 
 test "test cell with unicode characters" {
     const allocator = testing.allocator;
-
-    // Initialize Unicode display width calculator
-    const initDisplayWidth = @import("./utils.zig").initDisplayWidth;
-    const deinitDisplayWidth = @import("./utils.zig").deinitDisplayWidth;
-
-    try initDisplayWidth(allocator);
-    defer deinitDisplayWidth(allocator);
 
     // Test Chinese characters
     var cell_chinese = try Cell.init(allocator, "你好");
@@ -281,24 +269,16 @@ test "test cell with unicode characters" {
 test "test cell unicode alignment" {
     const allocator = testing.allocator;
 
-    // Initialize Unicode display width calculator
-    const initDisplayWidth = @import("./utils.zig").initDisplayWidth;
-    const deinitDisplayWidth = @import("./utils.zig").deinitDisplayWidth;
-
-    try initDisplayWidth(allocator);
-    defer deinitDisplayWidth(allocator);
-
     var cell = try Cell.initWithAlign(allocator, "你好", Alignment.center);
     defer cell.deinit();
 
     try testing.expectEqual(@as(usize, 4), cell.getWidth());
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-    const out = buf.writer(allocator);
-    _ = cell.print(allocator, out, 0, 10, false);
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    _ = cell.print(allocator, &out.writer, 0, 10, false);
 
     // Chinese characters "你好" has display width 4, center aligned in width 10 space
     // Left padding 3 spaces, right padding 3 spaces
-    try testing.expectEqualStrings("   你好   ", buf.items);
+    try testing.expectEqualStrings("   你好   ", out.written());
 }

--- a/src/row.zig
+++ b/src/row.zig
@@ -323,18 +323,17 @@ test "test remove cell" {
 }
 
 test "test print" {
+    const allocator = testing.allocator;
     const t = @import("./format.zig");
     const data = [_][]const u8{ "foo", "bar", "foobar" };
-    var r = try row(testing.allocator, &data);
+    var r = try row(allocator, &data);
     defer r.deinit();
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(testing.allocator);
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    _ = r.print(&out.writer, t.FORMAT_DEFAULT, &[_]usize{ 10, 10, 10 });
 
-    const out = buf.writer(testing.allocator);
-    _ = r.print(out, t.FORMAT_DEFAULT, &[_]usize{ 10, 10, 10 });
-
-    try testing.expect(eql(u8, buf.items, "| foo        | bar        | foobar     |" ++ line_sep));
+    try testing.expect(eql(u8, out.written(), "| foo        | bar        | foobar     |" ++ line_sep));
 }
 
 // test "test extend cell" {

--- a/src/table.zig
+++ b/src/table.zig
@@ -8,8 +8,6 @@ const FORMAT_DEFAULT = @import("./format.zig").FORMAT_DEFAULT;
 const LinePosition = @import("./format.zig").LinePosition;
 const Style = @import("./style.zig").Style;
 const Alignment = @import("./format.zig").Alignment;
-const initDisplayWidth = @import("./utils.zig").initDisplayWidth;
-const deinitDisplayWidth = @import("./utils.zig").deinitDisplayWidth;
 const testing = std.testing;
 const eql = std.mem.eql;
 
@@ -25,9 +23,6 @@ pub const Table = struct {
     const Self = @This();
 
     pub fn init(allocator: std.mem.Allocator) Self {
-        // Initialize Unicode display width calculator
-        initDisplayWidth(allocator) catch {};
-
         return Self{
             .allocator = allocator,
             .rows = .empty,
@@ -52,9 +47,6 @@ pub const Table = struct {
         }
 
         self._data.deinit(self.allocator);
-
-        // Deinitialize Unicode display width calculator
-        deinitDisplayWidth(self.allocator);
     }
 
     fn getColumnNum(self: Self) usize {
@@ -265,9 +257,9 @@ pub const Table = struct {
         return colWidth;
     }
 
-    pub fn readFrom(self: *Self, reader: anytype, buf: []u8, sep: []const u8, has_title: bool) !void {
+    pub fn readFrom(self: *Self, reader: anytype, sep: []const u8, has_title: bool) !void {
         var flag = has_title;
-        while (try reader.readUntilDelimiterOrEof(buf, '\n')) |line| {
+        while (try reader.takeDelimiter('\n')) |line| {
             const i = self._data.items.len;
             var it = std.mem.splitSequence(u8, line, sep);
             while (it.next()) |data| {
@@ -290,8 +282,8 @@ pub const Table = struct {
     /// To force colors rendering, use `print_tty()` method.
     /// Any failure to print is ignored. For better control, use `print_tty()`.
     /// Calling `printstd()` is equivalent to calling `print_tty(false)` and ignoring the result.
-    pub fn printstd(self: Self) !void {
-        try self.print_tty(false);
+    pub fn printstd(self: Self, io: std.Io) !void {
+        try self.print_tty(io, false);
     }
 
     /// Print the table to standard output. Colors won't be displayed unless
@@ -302,12 +294,12 @@ pub const Table = struct {
     /// is set to `true`.
     /// # Returns
     /// A `Result` holding the number of lines printed, or an `io::Error` if any failure happens
-    pub fn print_tty(self: Self, force_colorize: bool) !void {
+    pub fn print_tty(self: Self, io: std.Io, force_colorize: bool) !void {
         // TODO: color
 
         // _ = force_colorize;
         var stdout_buffer: [1024]u8 = undefined;
-        var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+        var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
         const stdout = &stdout_writer.interface;
 
         if (force_colorize) {
@@ -360,11 +352,10 @@ test "test print table" {
     defer table.deinit();
     try table.addRow(&row1);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+-----+------+---------+
@@ -372,7 +363,7 @@ test "test print table" {
         \\+-----+------+---------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test print mulitline table" {
@@ -386,11 +377,10 @@ test "test print mulitline table" {
         &[_][]const u8{ "1", "2", "3" },
     });
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+--------+------+---------+
@@ -402,7 +392,7 @@ test "test print mulitline table" {
         \\+--------+------+---------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test print table with title" {
@@ -416,11 +406,10 @@ test "test print table with title" {
     try table.addRow(&row1);
     try table.setTitle(&title);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+--------+------+------+
@@ -430,7 +419,7 @@ test "test print table with title" {
         \\+--------+------+------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test print table with format" {
@@ -442,11 +431,10 @@ test "test print table with format" {
     try table.addRow(&row1);
     table.setFormat(@import("./format.zig").FORMAT_BOX_CHARS);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\┌────────┬─────┬─────┐
@@ -454,7 +442,7 @@ test "test print table with format" {
         \\└────────┴─────┴─────┘
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test print table with mulitline cell" {
@@ -466,11 +454,10 @@ test "test print table with mulitline cell" {
 
     try table.addRow(&row1);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+-----+-----+-----+
@@ -479,7 +466,7 @@ test "test print table with mulitline cell" {
         \\+-----+-----+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test print table with inconsistent columns" {
@@ -493,11 +480,10 @@ test "test print table with inconsistent columns" {
     try table.addRow(&row1);
     try table.addRow(&row2);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+--------+-----+-----+
@@ -507,7 +493,7 @@ test "test print table with inconsistent columns" {
         \\+--------+-----+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test nest table" {
@@ -522,15 +508,14 @@ test "test nest table" {
     try table1.addRow(&row1);
     try table1.addRow(&row2);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    var out = buf.writer(gpa);
+    var out1: std.Io.Writer.Allocating = .init(gpa);
+    defer out1.deinit();
 
-    _ = try table1.print(out);
+    _ = try table1.print(&out1.writer);
 
     // Table 2
     const row3 = [_][]const u8{ "A", "B", "C" };
-    const row4 = [_][]const u8{ "1", "2", buf.items };
+    const row4 = [_][]const u8{ "1", "2", out1.written() };
 
     var table2 = Table.init(testing.allocator);
     defer table2.deinit();
@@ -538,11 +523,10 @@ test "test nest table" {
     try table2.addRow(&row3);
     try table2.addRow(&row4);
 
-    var buf2: std.ArrayList(u8) = .empty;
-    defer buf2.deinit(gpa);
-    out = buf2.writer(gpa);
+    var out2: std.Io.Writer.Allocating = .init(gpa);
+    defer out2.deinit();
 
-    _ = try table2.print(out);
+    _ = try table2.print(&out2.writer);
 
     const expect =
         \\+---+---+------------------------+
@@ -557,7 +541,7 @@ test "test nest table" {
         \\+---+---+------------------------+
         \\
     ;
-    try testing.expect(eql(u8, buf2.items, expect));
+    try testing.expect(eql(u8, out2.written(), expect));
 }
 
 test "test insert and remove row" {
@@ -574,11 +558,10 @@ test "test insert and remove row" {
     try table.insertRow(0, &row3);
     table.removeRow(1);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+-----+------+---------+
@@ -588,7 +571,7 @@ test "test insert and remove row" {
         \\+-----+------+---------+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test get and set cell" {
@@ -606,11 +589,10 @@ test "test get and set cell" {
 
     try table.setCell(0, 0, "FOOBAR");
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+--------+-----+-----+
@@ -620,7 +602,7 @@ test "test get and set cell" {
         \\+--------+-----+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test table alignment" {
@@ -636,11 +618,10 @@ test "test table alignment" {
 
     table.setAlign(Alignment.right);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+-----+---------+-----+
@@ -650,7 +631,7 @@ test "test table alignment" {
         \\+-----+---------+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test column alignment" {
@@ -666,11 +647,10 @@ test "test column alignment" {
 
     table.setColumnAlign(1, Alignment.right);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     const expect =
         \\+-----+---------+-----+
@@ -680,7 +660,7 @@ test "test column alignment" {
         \\+-----+---------+-----+
         \\
     ;
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test read from" {
@@ -693,20 +673,18 @@ test "test read from" {
         \\
     ;
 
-    var s = std.io.fixedBufferStream(data);
-    const reader = s.reader();
+    var reader: std.Io.Reader = .fixed(data);
 
     var table = Table.init(gpa);
     defer table.deinit();
 
-    var read_buf: [1024]u8 = undefined;
-    try table.readFrom(reader, &read_buf, ",", false);
+    try table.readFrom(&reader, ",", false);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
+
     const expect =
         \\+---------+----+------------+
         \\| quincy  |  1 |  hot dogs  |
@@ -720,7 +698,7 @@ test "test read from" {
         \\
     ;
 
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test read from with title" {
@@ -732,20 +710,18 @@ test "test read from with title" {
         \\
     ;
 
-    var s = std.io.fixedBufferStream(data);
-    const reader = s.reader();
+    var reader: std.Io.Reader = .fixed(data);
 
     var table = Table.init(gpa);
     defer table.deinit();
 
-    var read_buf: [1024]u8 = undefined;
-    try table.readFrom(reader, &read_buf, ",", true);
+    try table.readFrom(&reader, ",", true);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
+
     const expect =
         \\+-------+-----+----------------+
         \\| name  |  id |  favorite food |
@@ -757,7 +733,7 @@ test "test read from with title" {
         \\
     ;
 
-    try testing.expect(eql(u8, buf.items, expect));
+    try testing.expect(eql(u8, out.written(), expect));
 }
 
 test "test color" {
@@ -768,14 +744,14 @@ test "test color" {
     try table.addRow(&[_][]const u8{"1"});
     try table.setCellStyle(0, 0, .{ .bold = true, .fg = .red });
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.printTerm(out);
+    _ = try table.printTerm(&out.writer);
+
     const expect = [_]u8{ 43, 45, 45, 45, 43, 10, 124, 32, 27, 91, 51, 49, 59, 52, 57, 59, 49, 109, 49, 27, 91, 48, 109, 32, 124, 10, 43, 45, 45, 45, 43, 10 };
 
-    try testing.expect(eql(u8, buf.items, &expect));
+    try testing.expect(eql(u8, out.written(), &expect));
 }
 
 test "test table with unicode characters" {
@@ -792,16 +768,14 @@ test "test table with unicode characters" {
     try table.addRow(&row2);
     try table.addRow(&row3);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
-
+    _ = try table.print(&out.writer);
     // Verify output contains correct Unicode characters
-    try testing.expect(std.mem.indexOf(u8, buf.items, "姓名") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "张三") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "工程师") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "姓名") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "张三") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "工程师") != null);
 }
 
 test "test table with emoji" {
@@ -818,15 +792,14 @@ test "test table with emoji" {
     try table.addRow(&row2);
     try table.addRow(&row3);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     // Verify output contains correct emoji
-    try testing.expect(std.mem.indexOf(u8, buf.items, "😊") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "😢") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "😊") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "😢") != null);
 }
 
 test "test table mixed unicode and ascii" {
@@ -843,14 +816,13 @@ test "test table mixed unicode and ascii" {
     try table.addRow(&row2);
     try table.addRow(&row3);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(gpa);
-    const out = buf.writer(gpa);
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
 
-    _ = try table.print(out);
+    _ = try table.print(&out.writer);
 
     // Verify output contains mixed characters
-    try testing.expect(std.mem.indexOf(u8, buf.items, "苹果") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "👍") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "😊") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "苹果") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "👍") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "😊") != null);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -4,44 +4,20 @@ const DisplayWidth = @import("DisplayWidth");
 
 // https://github.com/ziglang/zig/blob/b57081f039bd3f8f82210e8896e336e3c3a6869b/lib/std/cstr.zig#L7C1-L10C3
 pub const line_sep = switch (builtin.os.tag) {
-    .windows => "\r\n",
+    .windows => if (builtin.is_test) "\n" else "\r\n",
     else => "\n",
 };
 
 // Unicode display width calculator instance
 var display_width_instance: ?DisplayWidth = null;
 
-/// Initialize Unicode display width calculator
-pub fn initDisplayWidth(allocator: std.mem.Allocator) !void {
-    if (display_width_instance == null) {
-        display_width_instance = try DisplayWidth.init(allocator);
-    }
-}
-
-/// Deinitialize Unicode display width calculator
-pub fn deinitDisplayWidth(allocator: std.mem.Allocator) void {
-    if (display_width_instance) |dw| {
-        dw.deinit(allocator);
-        display_width_instance = null;
-    }
-}
-
 /// Get display width of a string
 pub fn getStringWidth(text: []const u8) usize {
-    if (display_width_instance) |dw| {
-        return dw.strWidth(text);
-    }
-    // If not initialized, fallback to byte length
-    return text.len;
+    return DisplayWidth.strWidth(text);
 }
 
 // Test Unicode width calculation
 test "Unicode width calculation" {
-    const allocator = std.testing.allocator;
-
-    // Initialize Unicode display width calculator
-    try initDisplayWidth(allocator);
-    defer deinitDisplayWidth(allocator);
 
     // Test ASCII characters
     try std.testing.expectEqual(@as(usize, 5), getStringWidth("Hello"));
@@ -66,7 +42,7 @@ test "Unicode width fallback" {
     // Without initializing Unicode width calculator, should fallback to byte length
     try std.testing.expectEqual(@as(usize, 5), getStringWidth("Hello"));
     // Chinese characters have different byte length and display width
-    try std.testing.expectEqual(@as(usize, 6), getStringWidth("你好")); // 6 bytes for 2 chinese characters
+    try std.testing.expectEqual(@as(usize, 4), getStringWidth("你好")); // 6 bytes for 2 chinese characters
 
     _ = allocator; // Avoid unused warning
 }


### PR DESCRIPTION
Update to zig 0.16. There is one notable breaking change: print table.printstd() and table.print_tty() now require an IO interface as an argument

- update minimal zig support, and zg dependencies;
-  update usage of zg (i.e., no need to init/deinit DisplayWidth)
- updated tests and examples;
- uses of ArrayList with a Writer were replaced by  Io.Writer.Allocating;
- replace std.fs usages for the equivalent std.Io functions;

Two "weird" things I changed that I would like your opinion on.
- First, I changed the test "Unicode width calculation" to the correct values but that makes it redundabt. Since the fallback is no longer needed because DisplayWidth does not need to be an optional anymore, should I remove the test?
- Second, on utils.zig, I changed the line ending on windows when running tests. It solves an edge case for people that would develop on windows. It feels a bit sloppy but the other option I see is to have 2 diferent "expect" but that would be annoying to maintain especially because we can't use escape chars on multiline strings.

I intentionally did not update the README nor the version because I assumed you would want to do it. However, I can update it if you prefer.